### PR TITLE
docs: add Project Knowledge Map; align beads/gitignore tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,7 @@ __marimo__/
 .dolt/
 *.db
 .beads-credential-key
+.beads/proxieddb/
 
 # Gas Town (added by gt)
 .runtime/
@@ -219,3 +220,6 @@ __marimo__/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# Serena (semantic code toolkit — project config + cache, local tooling)
+.serena/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,21 @@
 # Agent Instructions
 
+## Project Knowledge Map
+
+`design-docs/` and `schemas/` are the project's source of truth. Consult them
+directly — do NOT copy their contents into bd memory or other notes (pointers only).
+
+- `design-docs/`
+  - `game_design/` — tone, storylets, player & interaction design. Start here for
+    "what the game is." (`tone_contract.md` is auto-loaded on session start.)
+  - `implementation/` — ARCHITECTURE, API_DESIGN, SCENE_AND_ENGINE, etc. Read the
+    relevant doc BEFORE architectural or API work.
+  - `plans/` — dated `YYYY-MM-DD-<topic>-design.md` + `-plan.md` pairs. Write new
+    design/plan docs HERE in this format (this is where plan artifacts live).
+- `schemas/` — JSON schemas; the source of truth for all data in `assets/`.
+  Schema-first: fix data to match the schema, never the reverse. To change a
+  schema, file a bd issue first.
+
 This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
 
 ## Quick Reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,22 @@
 - Load `design-docs/game_design/tone_contract.md` into context after compacting context.
 - If the user mentions new items that are not present in `assets/collectibles.json`, add them there (following `schemas/collectibles.schema.json`) before continuing.
 
+## Project Knowledge Map
+
+`design-docs/` and `schemas/` are the project's source of truth. Consult them
+directly — do NOT copy their contents into bd memory or other notes (pointers only).
+
+- `design-docs/`
+  - `game_design/` — tone, storylets, player & interaction design. Start here for
+    "what the game is." (`tone_contract.md` is auto-loaded on session start.)
+  - `implementation/` — ARCHITECTURE, API_DESIGN, SCENE_AND_ENGINE, etc. Read the
+    relevant doc BEFORE architectural or API work.
+  - `plans/` — dated `YYYY-MM-DD-<topic>-design.md` + `-plan.md` pairs. Write new
+    design/plan docs HERE in this format (this is where plan artifacts live).
+- `schemas/` — JSON schemas; the source of truth for all data in `assets/`.
+  Schema-first: fix data to match the schema, never the reverse. To change a
+  schema, file a bd issue first.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker
 
@@ -50,6 +66,3 @@ bd close <id>         # Complete work
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
-
-- Schema-first design: JSON schemas in `schemas/` are the source of truth. If data in `assets/` fails validation, fix the data to conform to the schema. Do not modify schemas to accommodate invalid data. If a schema genuinely needs updating, create an issue to discuss the change.
-


### PR DESCRIPTION
## Summary
- Add a shared **Project Knowledge Map** section to `CLAUDE.md` and `AGENTS.md` pointing agents at `design-docs/` and `schemas/` as the source of truth (schema-first; new plans go in `design-docs/plans/`). Folds the former bottom-of-file schema rule in `CLAUDE.md` into the new section, and closes the gap where `AGENTS.md` (Codex/other agents) said nothing about these dirs.
- Bring gitignores to current beads standards and ignore Serena tooling:
  - `.beads/.gitignore`: ignore `embeddeddolt/`, `proxieddb/`, `proxied_server_client_info.json`
  - `.gitignore`: add `.beads/proxieddb/` and `.serena/`

## Context
Split out from unrelated feature work so PR #50 stays focused. Companion to this session's beads 1.0.5 migration repair and the `kimberlygarmoe` → `chapters` issue-prefix rename (tracked in beads).

## Notes
- `.serena/` is now gitignored rather than committed (local semantic-toolkit config + cache).
- `uv.lock` intentionally left untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)